### PR TITLE
OWS service for GeoServer should be filtered

### DIFF
--- a/perfs/run.sh
+++ b/perfs/run.sh
@@ -18,7 +18,8 @@ do
     sleep 1
 done
 
-export base_urls="http://mapserver/|MapServer,http://qgis/|QGIS,http://geoserver:8080/ows|GeoServer"
+export
+base_urls="http://mapserver/|MapServer,http://qgis/|QGIS,http://geoserver:8080/OSM/ows|GeoServer"
 
 rm -r $GATLING_HOME/results/*
 


### PR DESCRIPTION
GeoServer prefix the layer name with workspace which will make the layername in
WMS request difficult to make generic with QGIS server and MapServer.
